### PR TITLE
Do not cancel the timer when visiting buffer where HTM is disabled

### DIFF
--- a/highlight-thing.el
+++ b/highlight-thing.el
@@ -80,8 +80,8 @@
   "Timer that triggers highlighting.")
 
 (defun highlight-thing-loop ()
-  (cond (highlight-thing-mode (highlight-thing-do))
-	(t (highlight-thing-deactivate))))
+  (when highlight-thing-mode
+    (highlight-thing-do)))
 
 (defun highlight-thing-deactivate ()
   (highlight-thing-remove-last)
@@ -125,15 +125,19 @@
     (highlight-thing-mode 1)))
 
 (defun highlight-thing-schedule-timer ()
-  (when highlight-thing-timer (cancel-timer highlight-thing-timer))
-  (setq highlight-thing-timer (run-with-idle-timer highlight-thing-delay-seconds t 'highlight-thing-loop)))
+  (unless highlight-thing-timer
+      (setq highlight-thing-timer
+            (run-with-idle-timer
+             highlight-thing-delay-seconds t 'highlight-thing-loop))))
 
 ;;;###autoload
 (define-minor-mode highlight-thing-mode
   "Minor mode that highlights things at point"
   nil " hlt" nil
   :group 'highlight-thing
-  (highlight-thing-schedule-timer))
+  (if highlight-thing-mode
+      (highlight-thing-schedule-timer)
+    (highlight-thing-remove-last)))
 
 ;;;###autoload
 (define-globalized-minor-mode global-highlight-thing-mode


### PR DESCRIPTION
If I have two buffers, one with HTM on and the other with HTM off, right now it works like this:

- in the first buffer, the timer is set up
- as soon as I wisit the second buffer, `highlight-thing-loop` sees that the mode is off and cancels the timer
- when I go back to the first buffer, the timer is canceled and so nothing happens. To reschedule the timer I need to turn the mode off and on again.

It took me a while to realize why I see this behaviour :)

The fix is simply to schedule one timer and never cancel it, checking if we want to do the action or not in the `highlight-thing-loop` function (which could probably be omited entirely and merged into `highlight-thing-do`.  The performance hit is negligible as the idle timer only runs once after the idle interval and the one if-check it does is completely irrelevant wrt any slowdowns. 

In `show-smartparens-mode` I use the same pattern, which I took in a simpified form from the built-in `show-paren-mode`.