### PR TITLE
fix: preserve point before widening and re-narrowing

### DIFF
--- a/highlight-thing.el
+++ b/highlight-thing.el
@@ -225,15 +225,16 @@ functionality."
 
 (defun highlight-thing-buffer-do (buf regex)
   (with-current-buffer buf
-    (save-restriction
-      (widen)
-      (cond ((highlight-thing-should-narrow-to-defun-p)
-	     (narrow-to-defun))
-	    ((highlight-thing-should-narrow-to-region-p)
-	     (let ((bounds (highlight-thing-narrow-bounds)))
-	       (narrow-to-region (car bounds) (cdr bounds)))))
-      (highlight-thing-call-highlight-regexp regex)
-      (when highlight-thing-exclude-thing-under-point (highlight-thing-remove-overlays-at-point regex)))))
+    (save-excursion
+      (save-restriction
+        (widen)
+        (cond ((highlight-thing-should-narrow-to-defun-p)
+               (narrow-to-defun))
+              ((highlight-thing-should-narrow-to-region-p)
+               (let ((bounds (highlight-thing-narrow-bounds)))
+                 (narrow-to-region (car bounds) (cdr bounds)))))
+        (highlight-thing-call-highlight-regexp regex)
+        (when highlight-thing-exclude-thing-under-point (highlight-thing-remove-overlays-at-point regex))))))
 
 (defun highlight-thing-call-highlight-regexp (regex)
   (unless (string= "" regex)


### PR DESCRIPTION
Some languages can narrow to a region not including point when invoking narrow-to-defun.  This will cause the cursor to jump around when the restriction is restored.

To prevent this, remember also the original point.